### PR TITLE
[PR] Drag & Drop Todo Delete 기능 구현

### DIFF
--- a/ToDoMeong.xcodeproj/project.pbxproj
+++ b/ToDoMeong.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		448960282CA2EACF00410DA7 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 448960272CA2EACF00410DA7 /* Localizable.xcstrings */; };
 		4489602A2CA2EB7100410DA7 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448960292CA2EB7100410DA7 /* String+Extension.swift */; };
 		449B07C72D8D966C0030FE9D /* CustomUIKitTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449B07C62D8D966C0030FE9D /* CustomUIKitTextField.swift */; };
+		449B08192DCC9EC00030FE9D /* TodoDropDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449B08182DCC9EC00030FE9D /* TodoDropDelegate.swift */; };
 		44A02E732CA59FFB003EE911 /* TabViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44A02E722CA59FFB003EE911 /* TabViewManager.swift */; };
 		44A02E752CA5AF21003EE911 /* WillAppearModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44A02E742CA5AF21003EE911 /* WillAppearModifier.swift */; };
 		44A02E772CA5AFA3003EE911 /* WillDisappearModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44A02E762CA5AFA3003EE911 /* WillDisappearModifier.swift */; };
@@ -134,6 +135,7 @@
 		448960272CA2EACF00410DA7 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		448960292CA2EB7100410DA7 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		449B07C62D8D966C0030FE9D /* CustomUIKitTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomUIKitTextField.swift; sourceTree = "<group>"; };
+		449B08182DCC9EC00030FE9D /* TodoDropDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoDropDelegate.swift; sourceTree = "<group>"; };
 		44A02E722CA59FFB003EE911 /* TabViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewManager.swift; sourceTree = "<group>"; };
 		44A02E742CA5AF21003EE911 /* WillAppearModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WillAppearModifier.swift; sourceTree = "<group>"; };
 		44A02E762CA5AFA3003EE911 /* WillDisappearModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WillDisappearModifier.swift; sourceTree = "<group>"; };
@@ -393,6 +395,7 @@
 				44ED3AC82C92E3F200E3E9CF /* TodoView.swift */,
 				44ED3AEF2C943EA100E3E9CF /* TodoRowView.swift */,
 				44895FFB2C9C36D900410DA7 /* DetailPhotoView.swift */,
+				449B08182DCC9EC00030FE9D /* TodoDropDelegate.swift */,
 				44ED3AF62C95D3F400E3E9CF /* Add */,
 				44ED3B1E2C99156800E3E9CF /* Edit */,
 			);
@@ -633,6 +636,7 @@
 				44ED3B0B2C98039800E3E9CF /* Todo.swift in Sources */,
 				44ED3AEA2C94336000E3E9CF /* Date+Extension.swift in Sources */,
 				44A02E772CA5AFA3003EE911 /* WillDisappearModifier.swift in Sources */,
+				449B08192DCC9EC00030FE9D /* TodoDropDelegate.swift in Sources */,
 				44ED3B192C9874D900E3E9CF /* TodoRepository.swift in Sources */,
 				448960242CA1B7E700410DA7 /* SettingView.swift in Sources */,
 				4489602A2CA2EB7100410DA7 /* String+Extension.swift in Sources */,

--- a/ToDoMeong/Presentation/Todo/TodoDropDelegate.swift
+++ b/ToDoMeong/Presentation/Todo/TodoDropDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  TodoDropDelegate.swift
+//  ToDoMeong
+//
+//  Created by 권대윤 on 5/8/25.
+//
+
+import SwiftUI
+import RealmSwift
+
+struct TodoDropDelegate: DropDelegate {
+    private let viewModel: TodoViewModel
+    private let shouldHandleDrop: Bool
+    
+    /// shouldHandleDrop이 true인 경우에만 drop delete handling이 진행됩니다.
+    init(viewModel: TodoViewModel, shouldHandleDrop: Bool) {
+        self.viewModel = viewModel
+        self.shouldHandleDrop = shouldHandleDrop
+    }
+    
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        return DropProposal(operation: .move)
+    }
+    
+    func dropEntered(info: DropInfo) {
+        viewModel.action(.draggingCancelTimerStop)
+    }
+    
+    func performDrop(info: DropInfo) -> Bool {
+        if shouldHandleDrop {
+            let providers = info.itemProviders(for: [.text])
+            
+            for provider in providers {
+                // 비동기적으로 문자열 추출
+                provider.loadItem(forTypeIdentifier: "public.text", options: nil) { (data, error) in
+                    if let text = data as? Data,
+                       let droppedString = String(data: text, encoding: .utf8) {
+                        if let objectId = try? ObjectId(string: droppedString) {
+                            DispatchQueue.main.async {
+                                self.viewModel.action(.dropDelete(targetID: objectId))
+                            }
+                        } else {
+                            // 형식이 유효하지 않음
+                            print("DEBUG: 유효하지 않은 ObjectId 문자열")
+                        }
+                    }
+                }
+            }
+        }
+        return true
+    }
+}

--- a/ToDoMeong/TodoRepository.swift
+++ b/ToDoMeong/TodoRepository.swift
@@ -162,4 +162,21 @@ final class TodoRepository {
             completionHandler(.failure(.failedToDelete))
         }
     }
+    
+    /// 일치하는 ObjectID의 데이터를 삭제합니다.
+    func deleteTodo(todoID: ObjectId, completionHandler: @escaping (Result<Void, RealmError>) -> Void) {
+        do {
+            let realm = try Realm()
+            try realm.write {
+                if let object = realm.object(ofType: Todo.self, forPrimaryKey: todoID) {
+                    realm.delete(object)
+                    print("DEBUG: Realm Delete Succeed")
+                    completionHandler(.success(()))
+                }
+            }
+        } catch {
+            print(error)
+            completionHandler(.failure(.failedToDelete))
+        }
+    }
 }


### PR DESCRIPTION
## 주요 작업
- DropDelegate를 활용해 drag & drop으로 Todo Delete 기능 구현

### TodoDropDelegate
```
1. drop 영역으로 진입 시 TodoViewModel에 dragging 취소 타이머 작동 정지 요청
2. shouldHandleDrop 프로퍼티를 이용해 drop handling 작업의 처리 여부를 구분
3. drop handling 작업 시 TodoViewModel에 Todo 데이터의 식별자를 넘겨 삭제 처리 요청
```

### TodoView
```
1. TodoListView와 PlusCircleButtonView에 drop modifer 적용
2. dragging 상태일 때 PlusCircleButton의 UI를 변경
3. PlusCircleButton에 bounce 애니메이션 적용
```

### TodoViewModel
```
1. Input에 dropDelete(ObjectId), onDragging, draggingCancelTimerStop 이벤트 추가
2. Todo 개수 동기화 시점 판단을 위해 count 프로퍼티 추가
```

### TodoRepository
```
1. ObjectID를 이용해 일치하는 Todo 데이터 삭제 메서드 추가
```





